### PR TITLE
Add context menu option to only scroll without re-ordering

### DIFF
--- a/package/contextMenuItems.js
+++ b/package/contextMenuItems.js
@@ -5,6 +5,12 @@ chrome.contextMenus.create({
 });
 
 chrome.contextMenus.create({
+    "title": "Scroll to Bottom",
+    "id": "scroll",
+    "contexts": ["browser_action"]
+});
+
+chrome.contextMenus.create({
     "title": "Scroll to Bottom + Order by Artist",
     "id": "scrollAndOrder",
     "contexts": ["browser_action"]
@@ -17,9 +23,15 @@ chrome.contextMenus.onClicked.addListener(function (info, tab) {
         });
     };
 
-    if (info.menuItemId === "scrollAndOrder") {
+    if (info.menuItemId === "scroll") {
         chrome.tabs.executeScript({
             file: 'scrollToBottom.js'
+        });
+    };
+
+    if (info.menuItemId === "scrollAndOrder") {
+        chrome.tabs.executeScript({
+            file: 'scrollToBottomAndOrder.js'
         });
     };
 });

--- a/package/scrollToBottom.js
+++ b/package/scrollToBottom.js
@@ -18,8 +18,7 @@ if (window.location.href == "https://open.spotify.com/collection/albums") {
             }
             else {
                 clearInterval(scroll);
-                console.log("Randomizer extension: Scrolled to bottom. Ordering albums...");
-                orderAlbums();
+                console.log("Randomizer extension: Scrolled to bottom.");
             }
         }, 1000);
 
@@ -27,22 +26,5 @@ if (window.location.href == "https://open.spotify.com/collection/albums") {
     }
     else {
         console.log("Randomizer extension: Cannot find correct divs for scrolling function.");
-    }
-}
-
-function orderAlbums() {
-    var albumElement = document.querySelectorAll('.container-fluid--noSpaceAround')[0].children[0];
-    var albumArray = Array.from(albumElement.children);
-    var sortedArray = albumArray.sort(function (a, b) {
-        aArtist = a.querySelector('.ellipsis-one-line span') == null ? a.querySelector('.ellipsis-one-line a').innerHTML.toLowerCase() : a.querySelector('.ellipsis-one-line span').innerText.toLowerCase();
-        bArtist = b.querySelector('.ellipsis-one-line span') == null ? b.querySelector('.ellipsis-one-line a').innerHTML.toLowerCase() : b.querySelector('.ellipsis-one-line span').innerText.toLowerCase();
-
-        if (aArtist < bArtist) return -1;
-        if (aArtist > bArtist) return 1;
-        return 0;
-    })
-
-    for (i = 0; i < sortedArray.length; i++) {
-        albumElement.parentNode.appendChild(sortedArray[i])
     }
 }

--- a/package/scrollToBottomAndOrder.js
+++ b/package/scrollToBottomAndOrder.js
@@ -1,0 +1,48 @@
+if (window.location.href == "https://open.spotify.com/collection/albums") {
+    var scrollDiv = document.getElementsByClassName("main-view-container__scroll-node")[0];
+    var scrollDivChild = document.getElementsByClassName("main-view-container__scroll-node-child")[0];
+    if (scrollDiv && scrollDivChild) {
+        var scrollAttempts = 0;
+        var currentHeight = scrollDivChild.scrollHeight;
+
+        var scroll = setInterval(function () {
+            scrollDiv.scrollTop = scrollDivChild.scrollHeight;
+            if (scrollAttempts < 5) {
+                if (currentHeight === scrollDivChild.scrollHeight) {
+                    scrollAttempts++;
+                }
+                else {
+                    currentHeight = scrollDivChild.scrollHeight;
+                    scrollAttempts = 0;
+                }
+            }
+            else {
+                clearInterval(scroll);
+                console.log("Randomizer extension: Scrolled to bottom. Ordering albums...");
+                orderAlbums();
+            }
+        }, 1000);
+
+        scroll;
+    }
+    else {
+        console.log("Randomizer extension: Cannot find correct divs for scrolling function.");
+    }
+}
+
+function orderAlbums() {
+    var albumElement = document.querySelectorAll('.container-fluid--noSpaceAround')[0].children[0];
+    var albumArray = Array.from(albumElement.children);
+    var sortedArray = albumArray.sort(function (a, b) {
+        aArtist = a.querySelector('.ellipsis-one-line span') == null ? a.querySelector('.ellipsis-one-line a').innerHTML.toLowerCase() : a.querySelector('.ellipsis-one-line span').innerText.toLowerCase();
+        bArtist = b.querySelector('.ellipsis-one-line span') == null ? b.querySelector('.ellipsis-one-line a').innerHTML.toLowerCase() : b.querySelector('.ellipsis-one-line span').innerText.toLowerCase();
+
+        if (aArtist < bArtist) return -1;
+        if (aArtist > bArtist) return 1;
+        return 0;
+    })
+
+    for (i = 0; i < sortedArray.length; i++) {
+        albumElement.parentNode.appendChild(sortedArray[i])
+    }
+}


### PR DESCRIPTION
Hi, great extension! As a workaround for issue #1, this PR adds a context menu option to scroll to the bottom of the album page without re-ordering anything. 

I also moved the existing `scrollToBottom.js` to `scrollToBottomAndOrder.js` to keep sense of the file names with the addition of the "new" `scrollToBottom.js`.

